### PR TITLE
fix: 修正错别字和部分未更新的文档

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -167,7 +167,7 @@ Options:
 
 ### 删除模板配置
 
-通过 `nstarter remove` 操作可删除配置的模板。此操作会同时删除模板配置，并清楚缓存文件。
+通过 `nstarter remove` 操作可删除配置的模板。此操作会同时删除模板配置，并清除缓存文件。
  
 ```bash
 nstarter remove <repo>

--- a/docs/docs/extension/plugins/mongodb.md
+++ b/docs/docs/extension/plugins/mongodb.md
@@ -62,7 +62,7 @@ export class MongodbComponent extends AbstractComponent {
   提供有 `transaction` 方法装饰器与 `repoSession` 参数装饰装饰器，来向服务的方法中自动注入数据库操作的上下文会话，以实现所有相关的业务操作都可以在同一个数据库事务中被提交。
 
   ```typescript
-  @provideSvc()
+  @service()
   export class UserService {
       @transaction()
       public async userCreateTransaction(

--- a/docs/docs/startup.md
+++ b/docs/docs/startup.md
@@ -26,7 +26,7 @@ sidebar_position: 1
 * 配置模默认板工程
 
   ```bash
-  nstarter config set template.default ssh://git@code.fineres.com:7999/fx/nstarter-ts-express.git
+  nstarter config set repo.default ssh://git@code.fineres.com:7999/fx/nstarter-ts-express.git
   nstarter update
   ```
 

--- a/docs/docs/tools/starter/index.md
+++ b/docs/docs/tools/starter/index.md
@@ -172,7 +172,7 @@ Options:
 
 ### 删除模板配置
 
-通过 `nstarter remove` 操作可删除配置的模板。此操作会同时删除模板配置，并清楚缓存文件。
+通过 `nstarter remove` 操作可删除配置的模板。此操作会同时删除模板配置，并清除缓存文件。
 
 ```bash
 nstarter remove <repo>

--- a/docs/static/img/logo.png
+++ b/docs/static/img/logo.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d47e69d619458db046a382c544cffbd5d74615900a30eb182ee51fd1915a5031
-size 53003

--- a/packages/plugin-mongodb/README.md
+++ b/packages/plugin-mongodb/README.md
@@ -58,7 +58,7 @@ export class MongodbComponent extends AbstractComponent {
   提供有 `transaction` 方法装饰器与 `repoSession` 参数装饰装饰器，来向服务的方法中自动注入数据库操作的上下文会话，以实现所有相关的业务操作都可以在同一个数据库事务中被提交。
 
   ```typescript
-  @provideSvc()
+  @service()
   export class UserService {
       @transaction()
       public async userCreateTransaction(


### PR DESCRIPTION
修改了两个文档中的错别字 `清楚`  $\rightarrow$ `清除`
- docs/docs/tools/starter/index.md
- cli/README.md

更新了文档中的配置项 `template`  $\rightarrow$ `repo`
- docs/docs/startup.md

更新了文档演示代码中的装饰器 `@provideSvc()`  $\rightarrow$ `@service()`
- packages/plugin-mongodb/README.md
- docs/docs/extension/plugins/mongodb.md